### PR TITLE
Fix module name in dependency list.

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -16,7 +16,7 @@
 	"Foo::Bar" : "lib/Foo/Bar.pm6"
     },
     "test-depends" : [
-	"Test::Meta"
+	"Test::META"
     ],
     "resources" : [
     ],


### PR DESCRIPTION
The tests currently fail because this dependency can't be found/installed, this change fixes that.